### PR TITLE
ANDROID-1176: Durning a reconnect to a wireless access point, app UI …

### DIFF
--- a/afero-sdk-softhub/src/main/java/io/afero/sdk/softhub/DeviceWifiSetup.java
+++ b/afero-sdk-softhub/src/main/java/io/afero/sdk/softhub/DeviceWifiSetup.java
@@ -109,12 +109,16 @@ public class DeviceWifiSetup {
                 }
             });
 
-        Hubby.localViewingStateChange(mDeviceModel.getId(), true);
+        localViewingStateChange(true);
     }
 
     public void stop() {
-        Hubby.localViewingStateChange(mDeviceModel.getId(), false);
+        localViewingStateChange(false);
         mDeviceUpdateSubscription = RxUtils.safeUnSubscribe(mDeviceUpdateSubscription);
+    }
+
+    protected void localViewingStateChange(boolean isViewing) {
+        Hubby.localViewingStateChange(mDeviceModel.getId(), isViewing);
     }
 
     public WifiState getSetupState() {
@@ -186,7 +190,7 @@ public class DeviceWifiSetup {
 
     private void updateSetupState() {
         WifiState ws = getStateFromAttribute(mSetupStateAttribute);
-        if (ws != null && !ws.equals(mSetupState)) {
+        if (ws != null) {
             mSetupState = ws;
             mSetupStateSubject.onNext(ws);
         }
@@ -194,7 +198,7 @@ public class DeviceWifiSetup {
 
     private void updateSteadyState() {
         WifiState ws = getStateFromAttribute(mSteadyStateAttribute);
-        if (ws != null && !ws.equals(mSteadyState)) {
+        if (ws != null) {
             mSteadyState = ws;
             mSteadyStateSubject.onNext(ws);
         }


### PR DESCRIPTION
…hangs, if issues arise

- Changed DeviceWifiSetup to updateSetupState and updateSteadyState to publish the new state even if it's the same as the current state.
- Changed DeviceWifiSetup to move Hubby.localViewingStateChange into an overridable method since Hubby lib isn't usable in a unit-test environment.
- Various changes to DeviceWifiSetupMock to allow this to be unit tested on the app side.