### PR TITLE
ANDROID-1172: DeviceModel API cleanup

### DIFF
--- a/afero-sdk-core/src/main/java/io/afero/sdk/client/afero/models/RequestResponse.java
+++ b/afero-sdk-core/src/main/java/io/afero/sdk/client/afero/models/RequestResponse.java
@@ -13,6 +13,13 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
         "requestId": 3,
         "statusCode": 202,
         "timestampMs": 1486512901475
+    },
+    {
+        "status": "FAILURE",
+        "statusCode": 400
+    },
+    {
+        "status": "NOT_ATTEMPTED"
     }
  */
 
@@ -20,6 +27,8 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 public class RequestResponse {
 
     public static final String STATUS_SUCCESS = "SUCCESS";
+    public static final String STATUS_FAILURE = "FAILURE";
+    public static final String STATUS_NOT_ATTEMPTED = "NOT_ATTEMPTED";
 
     public String status;
     public int requestId;

--- a/afero-sdk-core/src/main/java/io/afero/sdk/client/mock/MockAferoClient.java
+++ b/afero-sdk-core/src/main/java/io/afero/sdk/client/mock/MockAferoClient.java
@@ -27,6 +27,7 @@ public class MockAferoClient implements AferoClient {
     private final ResourceLoader mLoader;
     private DeviceAssociateResponse mDeviceAssociateResponse;
     private String mFileNameGetDevices = "getDevices.json";
+    private Observable<RequestResponse[]> postBatchAttributeWriteResponse;
 
     public MockAferoClient() {
         mLoader = new ResourceLoader();
@@ -44,15 +45,20 @@ public class MockAferoClient implements AferoClient {
 
     @Override
     public Observable<RequestResponse[]> postBatchAttributeWrite(DeviceModel deviceModel, DeviceRequest[] body, int maxRetryCount, int statusCode) {
-        RequestResponse[] response = new RequestResponse[body.length];
-        for (int i = 0; i < response.length; ++i) {
-            RequestResponse rr = new RequestResponse();
-            rr.requestId = i + 1;
-            rr.status = RequestResponse.STATUS_SUCCESS;
-            rr.timestampMs = System.currentTimeMillis();
-            response[i] = rr;
+
+        if (postBatchAttributeWriteResponse == null) {
+            RequestResponse[] response = new RequestResponse[body.length];
+            for (int i = 0; i < response.length; ++i) {
+                RequestResponse rr = new RequestResponse();
+                rr.requestId = i + 1;
+                rr.status = RequestResponse.STATUS_SUCCESS;
+                rr.timestampMs = System.currentTimeMillis();
+                response[i] = rr;
+            }
+            return Observable.just(response);
         }
-        return Observable.just(response);
+
+        return postBatchAttributeWriteResponse;
     }
 
     @Override
@@ -158,5 +164,9 @@ public class MockAferoClient implements AferoClient {
 
     public void setFileGetDevices(String file) {
         mFileNameGetDevices = file;
+    }
+
+    public void setPostBatchAttributeWriteResponse(Observable<RequestResponse[]> response) {
+        postBatchAttributeWriteResponse = response;
     }
 }

--- a/afero-sdk-core/src/main/java/io/afero/sdk/device/DeviceModel.java
+++ b/afero-sdk-core/src/main/java/io/afero/sdk/device/DeviceModel.java
@@ -365,7 +365,7 @@ public final class DeviceModel implements ControlModel {
     }
 
     public WriteAttributeOperation writeAttribute() {
-        return new WriteAttributeOperation(this);
+        return new WriteAttributeOperation(this, mAferoClient);
     }
 
     public void writeAttribute(DeviceProfile.Attribute attribute, AttributeValue value) {
@@ -562,7 +562,8 @@ public final class DeviceModel implements ControlModel {
     }
 
     void onWriteResult(WriteAttributeOperation.Result writeResult) {
-
+        // as results come in cancel the timers on corresponding attributes
+        // or let existing logic in update handle it?
     }
 
     Observable<RequestResponse[]> postAttributeWriteRequests(Collection<DeviceRequest> requests) {

--- a/afero-sdk-core/src/test/java/io/afero/sdk/device/WriteAttributeOperationTest.java
+++ b/afero-sdk-core/src/test/java/io/afero/sdk/device/WriteAttributeOperationTest.java
@@ -1,0 +1,230 @@
+package io.afero.sdk.device;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+
+import io.afero.sdk.client.afero.models.AttributeValue;
+import io.afero.sdk.client.afero.models.RequestResponse;
+import io.afero.sdk.client.mock.MockAferoClient;
+import io.afero.sdk.client.mock.ResourceLoader;
+import io.afero.sdk.conclave.models.DeviceError;
+import io.afero.sdk.conclave.models.DeviceSync;
+import rx.Observable;
+import rx.Observer;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertEquals;
+
+
+public class WriteAttributeOperationTest {
+
+    @Test
+    public void testAPIError() throws Exception {
+        final int ATTR_ID = 100;
+
+        makeTester()
+                .putAttribute(ATTR_ID, "1")
+                .commit()
+                .deviceUpdate(ATTR_ID, 1, "1")
+                .verifyResultStatus(ATTR_ID, WriteAttributeOperation.Result.Status.SUCCESS)
+        ;
+    }
+
+    @Test
+    public void testCommitWithoutAttributes() throws Exception {
+        makeTester()
+                .verifyCommitException()
+        ;
+    }
+
+    @Test
+    public void testSingleAttribute() throws Exception {
+        final int ATTR_ID = 100;
+
+        makeTester()
+                .putAttribute(ATTR_ID, "1")
+                .commit()
+                .deviceUpdate(ATTR_ID, 1, "1")
+                .verifyResultStatus(ATTR_ID, WriteAttributeOperation.Result.Status.SUCCESS)
+        ;
+    }
+
+    @Test
+    public void testMultipleAttributes() throws Exception {
+        final int ATTR_ID_1 = 100;
+        final int ATTR_ID_2 = 200;
+        final int ATTR_ID_3 = 300;
+
+        makeTester()
+                .putAttribute(ATTR_ID_1, "1")
+                .putAttribute(ATTR_ID_2, "2")
+                .putAttribute(ATTR_ID_3, "3")
+                .commit()
+
+                .deviceUpdate(ATTR_ID_1, 1, "1")
+                .deviceUpdate(ATTR_ID_2, 2, "2")
+                .deviceUpdate(ATTR_ID_3, 3, "3")
+
+                .verifyResultStatus(ATTR_ID_1, WriteAttributeOperation.Result.Status.SUCCESS)
+                .verifyResultStatus(ATTR_ID_2, WriteAttributeOperation.Result.Status.SUCCESS)
+                .verifyResultStatus(ATTR_ID_3, WriteAttributeOperation.Result.Status.SUCCESS)
+        ;
+    }
+
+    @Test
+    public void testMultipleAttributesWithRequestAPIErrors() throws Exception {
+        final int ATTR_ID_1 = 100;
+        final int ATTR_ID_2 = 200;
+        final int ATTR_ID_3 = 300;
+
+        makeTester()
+                .putAttribute(ATTR_ID_1, "1")
+                .putAttribute(ATTR_ID_2, "2")
+                .putAttribute(ATTR_ID_3, "3")
+
+                .commitWithRequestAPIErrors()
+
+                .deviceUpdate(ATTR_ID_1, 1, "1")
+
+                .verifyResultStatus(ATTR_ID_1, WriteAttributeOperation.Result.Status.SUCCESS)
+                .verifyResultStatus(ATTR_ID_2, WriteAttributeOperation.Result.Status.FAILURE)
+                .verifyResultStatus(ATTR_ID_3, WriteAttributeOperation.Result.Status.FAILURE)
+        ;
+    }
+
+    @Test
+    public void testMultipleAttributesWithHubErrors() throws Exception {
+        final int ATTR_ID_1 = 100;
+        final int ATTR_ID_2 = 200;
+        final int ATTR_ID_3 = 300;
+
+        makeTester()
+                .putAttribute(ATTR_ID_1, "1")
+                .putAttribute(ATTR_ID_2, "2")
+                .putAttribute(ATTR_ID_3, "3")
+                .commit()
+
+                .deviceUpdate(ATTR_ID_1, 1, "1")
+                .deviceError(2)
+                .deviceError(3)
+
+                .verifyResultStatus(ATTR_ID_1, WriteAttributeOperation.Result.Status.SUCCESS)
+                .verifyResultStatus(ATTR_ID_2, WriteAttributeOperation.Result.Status.FAILURE)
+                .verifyResultStatus(ATTR_ID_3, WriteAttributeOperation.Result.Status.FAILURE)
+        ;
+    }
+
+
+    Tester makeTester() throws IOException {
+        return new Tester();
+    }
+
+    private static class Tester {
+        final MockAferoClient aferoClient = new MockAferoClient();
+        final ResourceLoader resourceLoader = new ResourceLoader("resources/writeAttributeOperation/");
+        final DeviceProfile deviceProfile = resourceLoader.createObjectFromJSONResource("deviceProfile.json", DeviceProfile.class);
+        final DeviceModel deviceModel = new DeviceModel("device-id", deviceProfile, false, aferoClient);
+        final WriteAttributeOperation wao = new WriteAttributeOperation(deviceModel, aferoClient);
+        final Observer<WriteAttributeOperation.Result> waoObserver = new WAOTestObserver();
+
+        HashMap<Integer, WriteAttributeOperation.Result> writeResults = new HashMap<>();
+        Throwable error;
+        boolean isCompleted;
+
+        Tester() throws IOException {
+        }
+
+        Tester putAttribute(int attrId, String value) {
+            DeviceProfile.Attribute attribute = deviceModel.getAttributeById(attrId);
+            wao.put(attrId, new AttributeValue(value, attribute.getDataType()));
+            return this;
+        }
+
+        Tester commit() {
+            wao.commit().subscribe(waoObserver);
+            return this;
+        }
+
+        Tester commitWithRequestAPIErrors() {
+
+            RequestResponse[] response = new RequestResponse[3];
+            RequestResponse rr = new RequestResponse();
+            rr.requestId = 1;
+            rr.status = RequestResponse.STATUS_SUCCESS;
+            rr.timestampMs = System.currentTimeMillis();
+            response[0] = rr;
+
+            rr = new RequestResponse();
+            rr.status = RequestResponse.STATUS_FAILURE;
+            response[1] = rr;
+
+            rr = new RequestResponse();
+            rr.status = RequestResponse.STATUS_NOT_ATTEMPTED;
+            response[2] = rr;
+
+            aferoClient.setPostBatchAttributeWriteResponse(Observable.just(response));
+
+            wao.commit().subscribe(waoObserver);
+
+            return this;
+        }
+
+        Tester verifyResultStatus(int attrId, WriteAttributeOperation.Result.Status status) {
+            assertEquals(status, writeResults.get(attrId).status);
+            return this;
+        }
+
+        Tester deviceUpdate(int attr_id, int reqId, String value) {
+            DeviceSync ds = new DeviceSync();
+            ds.setDeviceId(deviceModel.getId());
+            ds.requestId = reqId;
+            ds.attribute = new DeviceSync.AttributeEntry(attr_id, value);
+
+            deviceModel.update(ds);
+
+            return this;
+        }
+
+        Tester deviceError(int reqId) {
+            DeviceError error = new DeviceError();
+            error.requestId = reqId;
+            error.status = "Status::FAIL";
+
+            deviceModel.onError(error);
+
+            return this;
+        }
+
+        Tester verifyCommitException() {
+            boolean caughtIllegalArgumentException = false;
+            try {
+                wao.commit().subscribe(waoObserver);
+            } catch (Exception e) {
+                caughtIllegalArgumentException = e instanceof IllegalArgumentException;
+            }
+            assertTrue(caughtIllegalArgumentException);
+            return this;
+        }
+
+        private class WAOTestObserver implements Observer<WriteAttributeOperation.Result> {
+
+            @Override
+            public void onCompleted() {
+                isCompleted = true;
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                error = e;
+            }
+
+            @Override
+            public void onNext(WriteAttributeOperation.Result result) {
+                writeResults.put(result.attributeId, result);
+            }
+        }
+    }
+
+}

--- a/afero-sdk-core/src/test/resources/writeAttributeOperation/deviceProfile.json
+++ b/afero-sdk-core/src/test/resources/writeAttributeOperation/deviceProfile.json
@@ -1,0 +1,78 @@
+{
+    "profileId": "94f11dea-4250-4ba6-8187-6b0fcdef04d4",
+    "schemaVersion": 1,
+    "profileVersion": 1,
+    "partnerId": "kiban-839f59e6-18a3-4d82-818d-42df5cc0c3cf",
+    "services": [
+        {
+            "id": 100,
+            "attributes": [
+                {
+                    "id": 100,
+                    "dataType": "sint8",
+                    "semanticType": "fan-speed",
+                    "operations": ["read","write"]
+                },
+                {
+                    "id": 200,
+                    "dataType": "sint16",
+                    "semanticType": "power",
+                    "operations": ["read","write"]
+                },
+                {
+                    "id": 300,
+                    "dataType": "sint32",
+                    "semanticType": "power",
+                    "operations": ["read","write"]
+                },
+                {
+                    "id": 400,
+                    "dataType": "sint64",
+                    "semanticType": "power",
+                    "operations": ["read","write"]
+                },
+                {
+                    "id": 500,
+                    "dataType": "float32",
+                    "semanticType": "power",
+                    "operations": ["read","write"]
+                },
+                {
+                    "id": 600,
+                    "dataType": "float64",
+                    "semanticType": "power",
+                    "operations": ["read","write"]
+                },
+                {
+                    "id": 700,
+                    "dataType": "boolean",
+                    "semanticType": "power",
+                    "operations": ["read","write"]
+                },
+                {
+                    "id": 800,
+                    "dataType": "fixed_16_16",
+                    "semanticType": "power",
+                    "operations": ["read","write"]
+                },
+                {
+                    "id": 900,
+                    "dataType": "fixed_32_32",
+                    "semanticType": "power",
+                    "operations": ["read","write"]
+                },
+                {
+                    "id": 50000,
+                    "dataType": "fixed_32_32",
+                    "semanticType": "power",
+                    "operations": ["read","write"]
+                },
+                {
+                    "id": 59002,
+                    "dataType": "BYTES",
+                    "operations": ["read","write"]
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
- Added logic to return FAILURE Result on device error (hub reported error).
- Added basic unit tests for WriteAttributeOperation.
- Added JavaDoc for WriteAttributeOperation.