### PR TITLE
ANDROID-1172: DeviceModel API cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,20 @@ Version 0.6.3 *(2017-08-??)*
    possibility of a version mismatch between the SDK and apps.
  * New: AfLog now support the notion of `FilterLevel` so the volume of logging output can
    be managed.
- * New: `DeviceModel.writeAttribute()` call replaces all variants of `writeModelValue()`,
+ * New: `DeviceModel.writeAttributes()` call replaces all variants of `writeModelValue()`,
    which have now been deprecated.
+ * `DeviceModel.setLocation(Location)` now performs the appropriate AferoClient call and
+   updates the DeviceModel's LocationState.
  * Fix: `DeviceWifiSetup` will no longer hang if the device was already connected, and wifi
    setup state doesn't change.
- * JavaDoc added for `DeviceModel`.
+ * New: `AferoClient.putDeviceLocation(String deviceId, Location location)` added to core.
+ * Added JavaDoc for `DeviceModel`.
  * Refactored parts of `ConclaveClient` and `DeviceWifiSetup` to remove deprecated RxJava calls.
  * `ConclaveDeviceEventSource.start` and `ConclaveDeviceEventSource.reconnect()` now return
     `Observable<ConclaveDeviceEventSource>`.
+ * Removed `ControlModel` interface.
+ * `DeviceModel.setProfile()` is now package-private.
+ * `DeviceModel.State` enum has been changed to `DeviceModel.UpdateState`.
 
 Version 0.6.2 *(2017-08-2)*
 ----------------------------

--- a/afero-sdk-client-retrofit2/src/main/java/io/afero/sdk/client/retrofit2/AferoClientRetrofit2.java
+++ b/afero-sdk-client-retrofit2/src/main/java/io/afero/sdk/client/retrofit2/AferoClientRetrofit2.java
@@ -610,6 +610,7 @@ public class AferoClientRetrofit2 implements AferoClient {
      * @param location Location to attach to the device
      * @return {@link Observable} that emits the attached Location in {@link rx.Observer#onNext}.
      */
+    @Override
     public Observable<Location> putDeviceLocation(String deviceId, Location location) {
         return mAferoService.putDeviceLocation(mActiveAccountId, deviceId, location)
                 .map(new RxUtils.Mapper<Void, Location>(location));

--- a/afero-sdk-core/src/main/java/io/afero/sdk/client/afero/AferoClient.java
+++ b/afero-sdk-core/src/main/java/io/afero/sdk/client/afero/AferoClient.java
@@ -30,6 +30,8 @@ public interface AferoClient {
 
     Observable<ConclaveAccessDetails> postConclaveAccess(String mobileClientId);
 
+    Observable<Location> putDeviceLocation(String deviceId, Location location);
+
     Observable<Location> getDeviceLocation(DeviceModel deviceModel);
 
     Observable<DeviceAssociateResponse> deviceAssociateGetProfile(String associationId, boolean isOwnershipVerified);

--- a/afero-sdk-core/src/main/java/io/afero/sdk/client/afero/models/LocationState.java
+++ b/afero-sdk-core/src/main/java/io/afero/sdk/client/afero/models/LocationState.java
@@ -7,51 +7,51 @@ package io.afero.sdk.client.afero.models;
 public class LocationState {
 
     public enum State {
-        Invalid,
-        None,
-        Valid
+        INVALID,
+        NONE,
+        VALID
     }
 
-    State state;
-    Location location;
+    private State state;
+    private Location location;
 
     public LocationState(Location location) {
         if (location == null) {
-            this.state = State.None;
+            this.state = State.NONE;
             return;
         }
 
-        if (location.latitude == null ||
-                location.longitude == null
-                // || location.formattedAddressLines == null
-                ) {
-            this.state = State.Invalid;
+        if (location.latitude == null || location.longitude == null) {
+            this.state = State.INVALID;
             return;
         }
 
-        this.state = State.Valid;
+        this.state = State.VALID;
         this.location = location;
     }
 
-    public LocationState(State state) {
-        if (state.equals(State.Valid)) {
+    public LocationState(State newState) {
+        if (newState.equals(State.VALID)) {
             throw new IllegalArgumentException("Valid LocationState must use LocationState(Location)");
         }
-        this.state = state;
+
+        state = newState;
     }
 
     public State getState() {
         return state;
     }
+
     public Location getLocation() {
-        if (state.equals(State.Valid)) {
+        if (state.equals(State.VALID)) {
             return location;
         }
+
         return null;
     }
 
     public String getAddress() {
-        if (state.equals(State.Valid) && location.formattedAddressLines != null) {
+        if (state.equals(State.VALID) && location.formattedAddressLines != null) {
             final StringBuilder sb = new StringBuilder();
             final String delim = System.getProperty("line.separator");
             int i = 0, n = location.formattedAddressLines.length;

--- a/afero-sdk-core/src/main/java/io/afero/sdk/client/mock/MockAferoClient.java
+++ b/afero-sdk-core/src/main/java/io/afero/sdk/client/mock/MockAferoClient.java
@@ -88,6 +88,11 @@ public class MockAferoClient implements AferoClient {
     }
 
     @Override
+    public Observable<Location> putDeviceLocation(String deviceId, Location location) {
+        return Observable.just(location);
+    }
+
+    @Override
     public Observable<Location> getDeviceLocation(DeviceModel deviceModel) {
         return null;
     }

--- a/afero-sdk-core/src/main/java/io/afero/sdk/device/DisplayRulesProcessor.java
+++ b/afero-sdk-core/src/main/java/io/afero/sdk/device/DisplayRulesProcessor.java
@@ -23,7 +23,7 @@ public class DisplayRulesProcessor<T> {
     private static final Pattern sBitwiseAndExpressionPattern = Pattern.compile("^\\&(0x\\d+|[-]?\\d+[.]?\\d*)$");
     private static final Pattern sBitwiseXorExpressionPattern = Pattern.compile("^\\^(0x\\d+|[-]?\\d+[.]?\\d*)$");
 
-    public static class RuleMatcher {
+    private static class RuleMatcher {
 
         static abstract class Operator {
             abstract boolean test(AttributeValue value);
@@ -343,14 +343,14 @@ public class DisplayRulesProcessor<T> {
         }
     }
 
-    private Rule[] mRules;
+    private Rule<T>[] mRules;
 
-    public DisplayRulesProcessor(Rule[] rules) {
+    public DisplayRulesProcessor(Rule<T>[] rules) {
         mRules = rules;
     }
 
     public void process(ApplyParams result, T model) {
-        for (Rule rule : mRules) {
+        for (Rule<T> rule : mRules) {
             rule.matchAndApply(result, model);
         }
     }

--- a/afero-sdk-core/src/main/java/io/afero/sdk/device/WriteAttributeOperation.java
+++ b/afero-sdk-core/src/main/java/io/afero/sdk/device/WriteAttributeOperation.java
@@ -161,7 +161,7 @@ public final class WriteAttributeOperation {
                 .doOnNext(notifyDeviceOfResult());
     }
 
-    // tell device about this Result so it can update its Device.State
+    // tell device about this Result so it can update its Device.UpdateState
     private Action1<Result> notifyDeviceOfResult() {
         return new Action1<Result>() {
             @Override
@@ -174,7 +174,7 @@ public final class WriteAttributeOperation {
         };
     }
 
-    // tell device about this error so it can update its Device.State
+    // tell device about this error so it can update its Device.UpdateState
     private Action1<Throwable> notifyDeviceOfError() {
         return new Action1<Throwable>() {
             @Override

--- a/afero-sdk-core/src/main/java/io/afero/sdk/scheduler/OfflineScheduler.java
+++ b/afero-sdk-core/src/main/java/io/afero/sdk/scheduler/OfflineScheduler.java
@@ -60,7 +60,7 @@ public class OfflineScheduler {
         mEventMaxCount = mDeviceModel.getProfile().getScheduleAttributeCount();
 
         mDeviceSyncSubscription = RxUtils.safeUnSubscribe(mDeviceSyncSubscription);
-        mDeviceSyncSubscription = mDeviceModel.getDeviceSyncObservable()
+        mDeviceSyncSubscription = mDeviceModel.getDeviceSyncPreUpdateObservable()
             .filter(new Func1<DeviceSync, Boolean>() {
                 @Override
                 public Boolean call(DeviceSync deviceSync) {
@@ -153,7 +153,7 @@ public class OfflineScheduler {
     }
 
     public synchronized void writeToDevice() {
-        WriteAttributeOperation writer = mDeviceModel.writeAttribute();
+        WriteAttributeOperation writer = mDeviceModel.writeAttributes();
 
         for (int i = 0; i < mEventMaxCount; ++i) {
             final int onAttrId = getEventIdAtIndex(i);
@@ -181,7 +181,7 @@ public class OfflineScheduler {
         DeviceProfile.Attribute attribute = mDeviceModel.getAttributeById(DeviceProfile.SCHEDULE_FLAGS_ATTRIBUTE_ID);
         if (attribute != null) {
             AttributeValue newValue = new AttributeValue(isOn ? "1" : "0", attribute.getDataType());
-            mDeviceModel.writeAttribute()
+            mDeviceModel.writeAttributes()
                 .put(attribute.getId(), newValue)
                 .commit()
                 .subscribe(new RxUtils.IgnoreResponseObserver<WriteAttributeOperation.Result>());
@@ -326,7 +326,7 @@ public class OfflineScheduler {
             if (isNewValueEmpty) {
                 newValue = mNullValue;
             }
-            mDeviceModel.writeAttribute()
+            mDeviceModel.writeAttributes()
                 .put(attribute.getId(), newValue)
                 .commit()
                 .subscribe(new RxUtils.IgnoreResponseObserver<WriteAttributeOperation.Result>());

--- a/afero-sdk-core/src/test/java/io/afero/sdk/device/DeviceModelTest.java
+++ b/afero-sdk-core/src/test/java/io/afero/sdk/device/DeviceModelTest.java
@@ -9,9 +9,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.math.BigDecimal;
-import java.util.Collection;
 import java.util.TreeMap;
-import java.util.Vector;
 
 import io.afero.sdk.AferoTest;
 import io.afero.sdk.client.afero.AferoClient;
@@ -19,7 +17,6 @@ import io.afero.sdk.client.afero.models.AttributeValue;
 import io.afero.sdk.client.mock.MockAferoClient;
 import io.afero.sdk.client.mock.ResourceLoader;
 import io.afero.sdk.conclave.models.DeviceSync;
-import rx.Observable;
 import rx.functions.Action1;
 
 import static org.junit.Assert.assertEquals;
@@ -43,7 +40,7 @@ public class DeviceModelTest extends AferoTest {
         DeviceProfile dp = loadDeviceProfile("resources/deviceModelTestProfile.json");
         DeviceModel dm = new DeviceModel(DEVICE_ID, dp, false, null);
 
-        assertEquals(DeviceModel.State.NORMAL, dm.getState());
+        assertEquals(DeviceModel.UpdateState.NORMAL, dm.getState());
         assertFalse(dm.isOTAInProgress());
         assertEquals(0, dm.getOTAProgress());
         assertEquals(dp.getId().length(), dm.getName().length());
@@ -135,7 +132,7 @@ public class DeviceModelTest extends AferoTest {
         }
 
         WriteAttributeTester deviceModelWriteAttribute(int attrId, String value, AttributeValue.DataType type) {
-            deviceModel.writeAttribute()
+            deviceModel.writeAttributes()
                 .put(attrId, new AttributeValue(value, type))
                 .commit()
                 .subscribe(new Action1<WriteAttributeOperation.Result>() {


### PR DESCRIPTION
* Added more JavaDoc for `DeviceModel`.
* Renamed `DeviceModel.writeAttribute()` to `writeAttributes()` since it can in fact write to multiple attributes.
* `DeviceModel.setLocation(Location)` now performs the appropriate AferoClient call and updates the DeviceModel's LocationState.
* New: `AferoClient.putDeviceLocation(String deviceId, Location location)` added to core.
* `DeviceModel.setProfile()` is now package-private.
* `DeviceModel.State` enum has been changed to `DeviceModel.UpdateState`.
* Fix: There were a couple of cases in `DeviceModel` where RxUtil.WeakAction was being instantiated as an anonymous inner class which defeats the purpose. These have been replaced with static inner classes that extend RxUtil.WeakAction.