### PR TITLE
ANDROID-1172: DeviceModel API cleanup

### DIFF
--- a/afero-sdk-core/src/main/java/io/afero/sdk/device/DeviceCollection.java
+++ b/afero-sdk-core/src/main/java/io/afero/sdk/device/DeviceCollection.java
@@ -505,7 +505,7 @@ public class DeviceCollection {
                                     updateDeviceProfile(deviceModel, profileId);
                                     break;
                                 case "location":
-                                    deviceModel.updateLocation();
+                                    deviceModel.invalidateLocationState();
                                     break;
                             }
                         } catch (Exception e) {


### PR DESCRIPTION
* `DeviceModel.getLocationState` now returns an `rx.Observable`. If the `DeviceModel` contains a valid location, it is returned immediately, otherwise the location is fetched from the Afero Cloud.
* `DeviceModel.setAvailable(boolean)` has been removed.
