### PR TITLE
ANDROID-1197: SDK: Support device timezone, localTimeFlag, and offlineSchedule conversion in DeviceModel/OfflineSchedule

### DIFF
--- a/afero-sdk-core/src/main/java/io/afero/sdk/utils/RxUtils.java
+++ b/afero-sdk-core/src/main/java/io/afero/sdk/utils/RxUtils.java
@@ -7,10 +7,12 @@ package io.afero.sdk.utils;
 import java.lang.ref.WeakReference;
 
 import io.afero.sdk.log.AfLog;
+import io.afero.sdk.scheduler.OfflineScheduler;
 import rx.Observable;
 import rx.Subscription;
 import rx.functions.Action0;
 import rx.functions.Action1;
+import rx.functions.Func0;
 import rx.functions.Func1;
 
 public class RxUtils {
@@ -147,4 +149,17 @@ public class RxUtils {
         }
     }
 
+    public static class ReturnFunc0<R> implements Func0<R> {
+
+        R result;
+
+        public ReturnFunc0(R r) {
+            result = r;
+        }
+
+        @Override
+        public R call() {
+            return result;
+        }
+    }
 }

--- a/afero-sdk-core/src/test/java/io/afero/sdk/scheduler/OfflineSchedulerTest.java
+++ b/afero-sdk-core/src/test/java/io/afero/sdk/scheduler/OfflineSchedulerTest.java
@@ -20,8 +20,12 @@ import io.afero.sdk.device.DeviceModelTest;
 import io.afero.sdk.device.DeviceProfile;
 import io.afero.sdk.log.AfLog;
 import io.afero.sdk.log.JavaLog;
+import rx.Observable;
+import rx.Observer;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 
 public class OfflineSchedulerTest extends AferoTest {
@@ -147,7 +151,28 @@ public class OfflineSchedulerTest extends AferoTest {
         DeviceProfile.Attribute attr2 = deviceModel.getAttributeById(59003);
         DeviceProfile.Attribute attr3 = deviceModel.getAttributeById(59004);
 
-        OfflineScheduler.migrateToDeviceTimeZone(deviceModel);
+        Observable<OfflineScheduleEvent> offlineScheduleMigration = OfflineScheduler.migrateToDeviceTimeZone(deviceModel);
+        assertNotNull(offlineScheduleMigration);
+
+        offlineScheduleMigration.toBlocking()
+            .subscribe(new Observer<OfflineScheduleEvent>() {
+                @Override
+                public void onCompleted() {
+
+                }
+
+                @Override
+                public void onError(Throwable e) {
+                    e.printStackTrace();
+                    assertTrue(false);
+                }
+
+                @Override
+                public void onNext(OfflineScheduleEvent offlineScheduleEvent) {
+                    assertTrue(offlineScheduleEvent.isInLocalTime());
+                }
+            }
+        );
 
         AttributeValue av = deviceModel.getAttributePendingValue(attr1);
         assertEquals("0302092D", av.toString());


### PR DESCRIPTION
Refactor OfflineScheduler.migrateToDeviceTimeZone to return an Observable so callers can react appropriately to error conditions.