### PR TITLE
ANDROID-1197: SDK: Support device timezone, localTimeFlag, and offlineSchedule conversion in DeviceModel/OfflineSchedule

### DIFF
--- a/afero-sdk-core/src/main/java/io/afero/sdk/device/DeviceModel.java
+++ b/afero-sdk-core/src/main/java/io/afero/sdk/device/DeviceModel.java
@@ -902,8 +902,7 @@ public final class DeviceModel {
                         @Override
                         public void onError(Throwable e) {
                             mMigrationSubscription = null;
-                            AfLog.i("DeviceModel.runDataMigrations: onError " + e);
-                            e.printStackTrace();
+                            AfLog.e("DeviceModel.runDataMigrations.onError: " + e.getMessage());
                         }
 
                         @Override

--- a/afero-sdk-core/src/test/java/io/afero/sdk/scheduler/OfflineSchedulerTest.java
+++ b/afero-sdk-core/src/test/java/io/afero/sdk/scheduler/OfflineSchedulerTest.java
@@ -184,4 +184,33 @@ public class OfflineSchedulerTest extends AferoTest {
         assertEquals("0304030D", av.toString());
     }
 
+    @Test
+    public void migrateAllToDeviceTimeZoneWithNoTimeZoneSet() throws Exception {
+        MockAferoClient aferoClient = new MockAferoClient();
+        DeviceSync data = loadDeviceSync("resources/offlineScheduleEvent/migrateDeviceSyncNoTimeZone.json");
+        DeviceModel deviceModel = DeviceModelTest.createDeviceModel(deviceProfile, aferoClient, data);
+
+        Observable<OfflineScheduleEvent> offlineScheduleMigration = OfflineScheduler.migrateToDeviceTimeZone(deviceModel);
+        assertNotNull(offlineScheduleMigration);
+
+        offlineScheduleMigration.toBlocking()
+            .subscribe(new Observer<OfflineScheduleEvent>() {
+                @Override
+                public void onCompleted() {
+                    assertTrue(false);
+                }
+
+                @Override
+                public void onError(Throwable e) {
+                    // we are expecting to get an error here.
+                }
+
+                @Override
+                public void onNext(OfflineScheduleEvent offlineScheduleEvent) {
+                    assertTrue(false);
+                }
+            }
+        );
+   }
+
 }

--- a/afero-sdk-core/src/test/resources/offlineScheduleEvent/migrateDeviceSyncNoTimeZone.json
+++ b/afero-sdk-core/src/test/resources/offlineScheduleEvent/migrateDeviceSyncNoTimeZone.json
@@ -1,0 +1,11 @@
+{
+    "attributes": [
+        { "id": 59002, "value": "0302092D" },
+        { "id": 59003, "value": "01030A1D" },
+        { "id": 59004, "value": "01040B0D" }
+    ],
+    "status": {
+        "available": true,
+        "visible": true
+    }
+}


### PR DESCRIPTION
Changed OfflineScheduler.migrateToDeviceTimeZone Observable error out if the device timeZone isn't set. This will cause DeviceModel to try again later when it does get set.
Added unit test for this case.