### PR TITLE
ANDROID-1191: AferoLab: Add device inspector view

### DIFF
--- a/afero-sdk-core/src/main/java/io/afero/sdk/device/DeviceProfile.java
+++ b/afero-sdk-core/src/main/java/io/afero/sdk/device/DeviceProfile.java
@@ -837,7 +837,7 @@ public class DeviceProfile {
 
         private void updateCount() {
             BigDecimal range = mMax.subtract(mMin);
-            mCount = range.divide(mStep, ROUNDING_MODE);
+            mCount = range.divide(mStep, ROUNDING_MODE).abs().add(BigDecimal.ONE);
         }
 
         public BigDecimal getCount() {
@@ -854,12 +854,16 @@ public class DeviceProfile {
         }
 
         public long getIndexByProportion(double proportion) {
-            return mCount.multiply(new BigDecimal(proportion)).setScale(0, ROUNDING_MODE).longValue();
+            if (mCount.compareTo(BigDecimal.ZERO) == 0) {
+                return 0;
+            }
+            BigDecimal index = mCount.subtract(BigDecimal.ONE);
+            return index.multiply(new BigDecimal(proportion)).setScale(0, ROUNDING_MODE).longValue();
         }
 
         public BigDecimal getValueByProportion(double proportion) {
-            BigDecimal index = mCount.multiply(new BigDecimal(proportion)).setScale(0, ROUNDING_MODE);
-            return mMin.add(mStep.multiply(index));
+            long index = getIndexByProportion(proportion);
+            return mMin.add(mStep.multiply(new BigDecimal(index)));
         }
 
         public double getProportionByValue(BigDecimal value) {

--- a/afero-sdk-core/src/test/java/io/afero/sdk/RangeOptionsTest.java
+++ b/afero-sdk-core/src/test/java/io/afero/sdk/RangeOptionsTest.java
@@ -82,6 +82,17 @@ public class RangeOptionsTest {
     }
 
     @Test
+    public void testGetCount() {
+        DeviceProfile.RangeOptions ro = new DeviceProfile.RangeOptions();
+
+        ro.setMin(BigDecimal.ZERO);
+        ro.setMax(new BigDecimal(99));
+        ro.setStep(BigDecimal.ONE);
+
+        assertTrue(ro.getCount().compareTo(new BigDecimal(100)) == 0);
+    }
+
+    @Test
     public void testIndexAndProportionWithIntegers() {
         DeviceProfile.RangeOptions ro = new DeviceProfile.RangeOptions();
 
@@ -89,7 +100,7 @@ public class RangeOptionsTest {
         ro.setMax(new BigDecimal(100));
         ro.setStep(BigDecimal.ONE);
 
-        assertTrue(ro.getCount().compareTo(new BigDecimal(100)) == 0);
+        assertTrue(ro.getCount().compareTo(new BigDecimal(101)) == 0);
 
         BigDecimal value = ro.getValueByIndex(50);
         assertTrue(value.compareTo(new BigDecimal(50)) == 0);
@@ -118,10 +129,18 @@ public class RangeOptionsTest {
         ro.setMax(max);
         ro.setStep(step);
 
-        assertTrue(ro.getCount().compareTo(new BigDecimal(4)) == 0);
+        assertTrue(ro.getCount().compareTo(new BigDecimal(5)) == 0);
 
-        BigDecimal value = ro.getValueByIndex(1);
+        BigDecimal value = ro.getValueByIndex(0);
+        assertTrue(value.compareTo(new BigDecimal("1.000")) == 0);
+        value = ro.getValueByIndex(1);
         assertTrue(value.compareTo(new BigDecimal("1.025")) == 0);
+        value = ro.getValueByIndex(2);
+        assertTrue(value.compareTo(new BigDecimal("1.050")) == 0);
+        value = ro.getValueByIndex(3);
+        assertTrue(value.compareTo(new BigDecimal("1.075")) == 0);
+        value = ro.getValueByIndex(4);
+        assertTrue(value.compareTo(new BigDecimal("1.100")) == 0);
 
         value = ro.getValueByProportion(0);
         assertTrue(value.compareTo(min) == 0);

--- a/samples/afero-lab/app/src/main/java/io/afero/aferolab/AttributeEditorController.java
+++ b/samples/afero-lab/app/src/main/java/io/afero/aferolab/AttributeEditorController.java
@@ -39,7 +39,7 @@ class AttributeEditorController {
 
         if (mValueOptions != null) {
             mRange = makeRangeFromValueOptions();
-            mView.setAttributeValueSliderMax(mValueOptions.length - 1);
+            mView.setAttributeValueSliderMax(mRange.getMax().intValue());
 
             for (DeviceProfile.DisplayRule vo : mValueOptions) {
                 mView.addEnumItem(vo.getApplyLabel(), vo.match);
@@ -184,17 +184,17 @@ class AttributeEditorController {
     }
 
     private int getValueOptionsIndex(AttributeValue value) {
-        String stringValue = value.toString();
         int i = 0;
 
         for (DeviceProfile.DisplayRule vo : mValueOptions) {
-            if (stringValue.equals(vo.match)) {
-                break;
+            AttributeValue matchValue = new AttributeValue(vo.match, value.getDataType());
+            if (matchValue.compareTo(value) == 0) {
+                return i;
             }
             ++i;
         }
 
-        return i;
+        return 0;
     }
 
     private AttributeEditorView.ValueEditorType getAttributeValueEditorType() {


### PR DESCRIPTION
DeviceProfile.RangeOptions:
 - Fixed some math so that getCount() returns that actual count instead of count - 1. ((max-min)/step) + 1
 - Changed getIndexByProportion and getValueByProportion to work with the real count.

RangeOptionsTest:
 - Update tests to expect the correct count and to test getCount() in isolation.

AttributeEditorController:
 - Use correct comparison logic in getValueOptionsIndex.