### PR TITLE
DeviceProfile.RangeOptions:

### DIFF
--- a/afero-sdk-core/src/main/java/io/afero/sdk/device/DeviceProfile.java
+++ b/afero-sdk-core/src/main/java/io/afero/sdk/device/DeviceProfile.java
@@ -849,21 +849,16 @@ public class DeviceProfile {
         }
 
         public long getIndexByValue(BigDecimal value) {
-            final double proportion = getProportionByValue(value);
-            return mCount.multiply(new BigDecimal(proportion)).setScale(0, ROUNDING_MODE).longValue();
+            return getIndexByProportion(getProportionByValue(value));
         }
 
         public long getIndexByProportion(double proportion) {
-            if (mCount.compareTo(BigDecimal.ZERO) == 0) {
-                return 0;
-            }
-            BigDecimal index = mCount.subtract(BigDecimal.ONE);
-            return index.multiply(new BigDecimal(proportion)).setScale(0, ROUNDING_MODE).longValue();
+            return getBigIndexByProportion(proportion).longValue();
         }
 
         public BigDecimal getValueByProportion(double proportion) {
-            long index = getIndexByProportion(proportion);
-            return mMin.add(mStep.multiply(new BigDecimal(index)));
+            BigDecimal index = getBigIndexByProportion(proportion);
+            return mMin.add(mStep.multiply(index));
         }
 
         public double getProportionByValue(BigDecimal value) {
@@ -878,6 +873,15 @@ public class DeviceProfile {
 
             return prop.doubleValue();
         }
+
+        private BigDecimal getBigIndexByProportion(double proportion) {
+            if (mCount.compareTo(BigDecimal.ZERO) == 0) {
+                return BigDecimal.ZERO;
+            }
+            BigDecimal index = mCount.subtract(BigDecimal.ONE);
+            return index.multiply(new BigDecimal(proportion)).setScale(0, ROUNDING_MODE);
+        }
+
     }
 
     @JsonIgnoreProperties(ignoreUnknown=true)

--- a/afero-sdk-core/src/test/java/io/afero/sdk/RangeOptionsTest.java
+++ b/afero-sdk-core/src/test/java/io/afero/sdk/RangeOptionsTest.java
@@ -14,6 +14,7 @@ import java.math.BigDecimal;
 
 import io.afero.sdk.device.DeviceProfile;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -90,6 +91,18 @@ public class RangeOptionsTest {
         ro.setStep(BigDecimal.ONE);
 
         assertTrue(ro.getCount().compareTo(new BigDecimal(100)) == 0);
+    }
+
+    @Test
+    public void testMinMaxInt64() {
+        DeviceProfile.RangeOptions ro = new DeviceProfile.RangeOptions();
+
+        ro.setMin(new BigDecimal(Long.MIN_VALUE));
+        ro.setMax(new BigDecimal(Long.MAX_VALUE));
+        ro.setStep(BigDecimal.ONE);
+
+        assertTrue(ro.getMin().compareTo(ro.getValueByProportion(0)) == 0);
+        assertTrue(ro.getMax().compareTo(ro.getValueByProportion(1)) == 0);
     }
 
     @Test


### PR DESCRIPTION
 - Minor refactor to avoid ever converting the count/index to a non-BigDecimal so we can properly handle a range of min/max Long.
 - Added unit test testMinMaxInt64()