### PR TITLE
Update to latest Hubby with enterprise changes.

### DIFF
--- a/afero-sdk-softhub/build.gradle
+++ b/afero-sdk-softhub/build.gradle
@@ -14,7 +14,7 @@ repositories {
     }
 }
 
-final String hubbyVersion = "1.0.825"
+final String hubbyVersion = "1.0.832"
 final String hubType = project.findProperty('aferoSofthubType') ?: '"CONSUMER"'
 
 android {

--- a/afero-sdk-softhub/src/main/java/io/afero/sdk/softhub/AferoSofthub.java
+++ b/afero-sdk-softhub/src/main/java/io/afero/sdk/softhub/AferoSofthub.java
@@ -304,7 +304,12 @@ public class AferoSofthub {
             }
         }
 
-        final String setupDirName = "shs" + (Build.MANUFACTURER + Build.MODEL + mAferoClient.getActiveAccountId()).hashCode();
+        final String setupDirName = "shs" + (
+            Build.MANUFACTURER +
+            Build.MODEL +
+            mHubType.toString() +
+            mAferoClient.getActiveAccountId()
+        ).hashCode();
 
         HashMap<Hubby.Config,String> config = new HashMap<>(1);
         config.put(Hubby.Config.SOFT_HUB_SETUP_PATH, mSetupPath + "/" + setupDirName);
@@ -354,14 +359,14 @@ public class AferoSofthub {
                     AfLog.e("AferoSofthub startup error - deviceAssociate failed");
                     AfLog.e(e);
 
-                    Hubby.secureHubAssociationCompleted(Hubby.AssociationStatus.FAILED_PERMANENT);
+                    mHubbyImpl.secureHubAssociationCompleted(Hubby.AssociationStatus.FAILED_PERMANENT);
 
                     startError(e);
                 }
 
                 @Override
                 public void onNext(DeviceAssociateResponse response) {
-                    Hubby.secureHubAssociationCompleted(Hubby.AssociationStatus.SUCCESS);
+                    mHubbyImpl.secureHubAssociationCompleted(Hubby.AssociationStatus.SUCCESS);
                     mAssociateSubject.onNext(response.deviceId);
                 }
             });
@@ -587,6 +592,8 @@ public class AferoSofthub {
         void stop();
 
         String getDeviceId();
+
+        void secureHubAssociationCompleted(Hubby.AssociationStatus status);
     }
 
     private class NativeHubbyImpl implements HubbyImpl {
@@ -613,6 +620,11 @@ public class AferoSofthub {
         @Override
         public String getDeviceId() {
             return Hubby.getId();
+        }
+
+        @Override
+        public void secureHubAssociationCompleted(Hubby.AssociationStatus status) {
+            Hubby.secureHubAssociationCompleted(status);
         }
     }
 

--- a/afero-sdk-softhub/src/test/java/io/afero/sdk/softhub/AferoSofthubTest.java
+++ b/afero-sdk-softhub/src/test/java/io/afero/sdk/softhub/AferoSofthubTest.java
@@ -507,6 +507,11 @@ public class AferoSofthubTest {
             return "mock-hub-id";
         }
 
+        @Override
+        public void secureHubAssociationCompleted(Hubby.AssociationStatus status) {
+
+        }
+
         void callbackInitializationCompleted() {
             mCallback.initializationComplete();
         }

--- a/samples/afero-lab/app/build.gradle
+++ b/samples/afero-lab/app/build.gradle
@@ -64,7 +64,7 @@ dependencies {
     implementation "io.afero.sdk:afero-sdk-client-retrofit2:${sdkVersion}"
     implementation "io.afero.sdk:afero-sdk-android:${sdkVersion}@aar"
     implementation "io.afero.sdk:afero-sdk-softhub:${sdkVersion}@aar"
-    implementation "io.afero.sdk:hubby:1.0.825@aar"
+    implementation "io.afero.sdk:hubby:1.0.832@aar"
 
     // https://github.com/square/retrofit
     implementation 'com.squareup.retrofit2:retrofit:2.3.0'


### PR DESCRIPTION
- Updated to Hubby 832.
- Hash the HubType into the setup path, so Hubby will use differents setups for ENTERPRISE and CONSUMER.
- Fix unit test by calling Hubby.secureHubAssociationCompleted via HubbyImpl, instead of directly.

## JIRA
[ANDROID-1592: Pull in softhub build with enterprise changes, and add hub startup mode flag to hubby persistent store path](https://kibanlabs.atlassian.net/browse/ANDROID-1592)