### PR TITLE
Changed: `AferoClient.internalRefreshAccessToken` is now protected in…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+Version 1.4.2 *(2019-08-06)*
+----------------------------
+ * Changed: `AferoClient.internalRefreshAccessToken` is now protected instead of private.
+
 Version 1.4.1 *(2019-08-05)*
 ----------------------------
  * New: Added a new `AferoClient.createAccount` overload that accepts `appId` and `platform` to enabled custom partner verification emails

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 ---
 author: Tony Myles
 title: "AferoJavaSDK"
-date: 2019-Aug-05
-status: 1.4.1
+date: 2019-Aug-06
+status: 1.4.2
 ---
 
 # AferoJavaSDK
@@ -35,23 +35,23 @@ The SDK is composed of four separate modules.
 
 The `afero-sdk-core` module is required for base functionality such as interacting with the Afero Cloud and manipulating devices.
 ```Gradle
-    implementation 'io.afero.sdk:afero-sdk-core:1.4.1'
+    implementation 'io.afero.sdk:afero-sdk-core:1.4.2'
 ```
 
 The `afero-sdk-client-retrofit2` module provides an optional implementation of the AferoClient REST API interface using [Retrofit2](http://square.github.io/retrofit/) and [okhttp3](http://square.github.io/okhttp/). If you choose not to include this module in your project, you will need to develop your own implementation of AferoClient using your preferred http client library.
 
 ```Gradle
-    implementation 'io.afero.sdk:afero-sdk-client-retrofit2:1.4.1'
+    implementation 'io.afero.sdk:afero-sdk-client-retrofit2:1.4.2'
 ```
 
 The `afero-sdk-android` module is required for Android development.
 ```Gradle
-    implementation 'io.afero.sdk:afero-sdk-android:1.4.1'
+    implementation 'io.afero.sdk:afero-sdk-android:1.4.2'
 ```
 
 The `afero-sdk-softhub` module is required for soft hub functionality on Android.
 ```Gradle
-    implementation 'io.afero.sdk:afero-sdk-softhub:1.4.1'
+    implementation 'io.afero.sdk:afero-sdk-softhub:1.4.2'
     implementation "io.afero.sdk:hubby:1.0.842@aar"
 ```
 

--- a/afero-sdk-client-retrofit2/src/main/java/io/afero/sdk/client/retrofit2/AferoClientRetrofit2.java
+++ b/afero-sdk-client-retrofit2/src/main/java/io/afero/sdk/client/retrofit2/AferoClientRetrofit2.java
@@ -1014,7 +1014,7 @@ public class AferoClientRetrofit2 implements AferoClient {
         }
     }
 
-    private AccessToken internalRefreshAccessToken(String refreshToken, String grantType) throws IOException {
+    protected AccessToken internalRefreshAccessToken(String refreshToken, String grantType) throws IOException {
         Response<AccessToken> response = mAferoService
                 .refreshAccessToken(grantType, refreshToken, mOAuthAuthorizationBase64)
                 .execute();


### PR DESCRIPTION
…stead of private.

Bumped version to 1.4.2