### PR TITLE
Fix for ConclaveDeviceEventSource.stop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Change Log
 ==========
 
+Version 1.4.4 *(2019-09-09)*
+----------------------------
+ * Fixed: Added logic to `ConclaveDeviceEventSource.stop()` to clear the access credentials and account id.
+ * Removed: `ConclaveDeviceEventSource.setAccountId()` since this function is defunct.
+
 Version 1.4.3 *(2019-08-22)*
 ----------------------------
  * Changed: Updated `AferoSofthub` to softhub version 1.0.844 to pick up latest fixes.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 ---
 author: Tony Myles
 title: "AferoJavaSDK"
-date: 2019-Aug-22
-status: 1.4.3
+date: 2019-Sept-9
+status: 1.4.4
 ---
 
 # AferoJavaSDK
@@ -35,23 +35,23 @@ The SDK is composed of four separate modules.
 
 The `afero-sdk-core` module is required for base functionality such as interacting with the Afero Cloud and manipulating devices.
 ```Gradle
-    implementation 'io.afero.sdk:afero-sdk-core:1.4.3'
+    implementation 'io.afero.sdk:afero-sdk-core:1.4.4'
 ```
 
 The `afero-sdk-client-retrofit2` module provides an optional implementation of the AferoClient REST API interface using [Retrofit2](http://square.github.io/retrofit/) and [okhttp3](http://square.github.io/okhttp/). If you choose not to include this module in your project, you will need to develop your own implementation of AferoClient using your preferred http client library.
 
 ```Gradle
-    implementation 'io.afero.sdk:afero-sdk-client-retrofit2:1.4.3'
+    implementation 'io.afero.sdk:afero-sdk-client-retrofit2:1.4.4'
 ```
 
 The `afero-sdk-android` module is required for Android development.
 ```Gradle
-    implementation 'io.afero.sdk:afero-sdk-android:1.4.3'
+    implementation 'io.afero.sdk:afero-sdk-android:1.4.4'
 ```
 
 The `afero-sdk-softhub` module is required for soft hub functionality on Android.
 ```Gradle
-    implementation 'io.afero.sdk:afero-sdk-softhub:1.4.3'
+    implementation 'io.afero.sdk:afero-sdk-softhub:1.4.4'
     implementation "io.afero.sdk:hubby:1.0.844@aar"
 ```
 

--- a/afero-sdk-core/src/main/java/io/afero/sdk/device/ConclaveDeviceEventSource.java
+++ b/afero-sdk-core/src/main/java/io/afero/sdk/device/ConclaveDeviceEventSource.java
@@ -109,12 +109,6 @@ public class ConclaveDeviceEventSource implements DeviceEventSource {
         return mAccountId != null;
     }
 
-    public void setAccountId(String accountId) {
-        mAccountId = accountId;
-        mConclaveAccessManager.resetAccess();
-        mConclaveAccessDetails = null;
-    }
-
     public void setSessionTracing(boolean enabled) {
         mSessionTrace = enabled;
     }
@@ -145,6 +139,10 @@ public class ConclaveDeviceEventSource implements DeviceEventSource {
             mConclaveSubscription.unsubscribe();
             mConclaveSubscription = null;
         }
+
+        mAccountId = null;
+        mConclaveAccessManager.resetAccess();
+        mConclaveAccessDetails = null;
 
         mConclaveClient.close();
     }

--- a/samples/afero-lab/app/build.gradle
+++ b/samples/afero-lab/app/build.gradle
@@ -5,7 +5,7 @@
 apply plugin: 'com.android.application'
 
 final String sdkRepoKey = project.findProperty('aferoSDKConsumeRepoKey') ?: 'afero-java-sdk'
-final String sdkVersion = project.findProperty('aferoSDKVersion') ?: '1.4.3'
+final String sdkVersion = project.findProperty('aferoSDKVersion') ?: '1.4.4'
 
 repositories {
     maven {


### PR DESCRIPTION
`Fixed:` Added logic to `ConclaveDeviceEventSource.stop()` to clear the… access credentials and account id.
`Removed:` `ConclaveDeviceEventSource.setAccountId()` since this function is defunct.
Updated version to 1.4.4.